### PR TITLE
Add initial styles, converting the table to a list of cards

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -51,3 +51,10 @@ added 373 packages, and audited 374 packages in 4s
 - document.getElementById("search-term").innerHTML = searchTerm is unnecessarily unsafe
 
 3:11 - Time Check: Resolved build and search errors and added typescript definition.
+
+3:35 - Begin frontend styling
+4:05 - Add initial styles to convert from table to card layout
+- TODO: Search section is unformatted and...ugly
+- TODO: Phone numbers are unformatted.
+- TODO: Specialties take up a lot of room visually. Perhaps collapse or .join() into a paragraph instead of a list.
+- TODO: Cards are missing some personality.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -71,52 +71,34 @@ export default function Home() {
   };
 
   return (
-    <main style={{ margin: "24px" }}>
-      <h1>Solace Advocates</h1>
-      <br />
-      <br />
-      <div>
+    <main className="container mx-auto p-6">
+      <h1 className="font-serif text-center text-2xl">Solace Advocates</h1>
+      <div className="text-center">
         <p>Search</p>
+        <input className="border" ref={searchInput} onChange={onSearchChange} />
+        <button onClick={onResetClick}>Reset Search</button>
         <p>
           Searching for: <span ref={searchTermElement}></span>
         </p>
-        <input ref={searchInput} style={{ border: "1px solid black" }} onChange={onSearchChange} />
-        <button onClick={onResetClick}>Reset Search</button>
       </div>
-      <br />
-      <br />
-      <table>
-        <thead>
-          <tr>
-            <th>First Name</th>
-            <th>Last Name</th>
-            <th>City</th>
-            <th>Degree</th>
-            <th>Specialties</th>
-            <th>Years of Experience</th>
-            <th>Phone Number</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filteredAdvocates.map((advocate) => {
-            return (
-              <tr key={advocate.firstName + advocate.lastName}>
-                <td>{advocate.firstName}</td>
-                <td>{advocate.lastName}</td>
-                <td>{advocate.city}</td>
-                <td>{advocate.degree}</td>
-                <td>
-                  {advocate.specialties.map((s) => (
-                    <div key={s}>{s}</div>
-                  ))}
-                </td>
-                <td>{advocate.yearsOfExperience}</td>
-                <td>{advocate.phoneNumber}</td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+      <div className="grid gap-6 my-6 lg:grid-cols-3 md:grid-cols-2">
+        {filteredAdvocates.map(advocate => {
+          return (
+            <div className="p-6 border rounded-lg shadow-lg" key={advocate.firstName + advocate.lastName}>
+              <h3 className="font-serif font-bold text-xl">{advocate.firstName} {advocate.lastName}, {advocate.degree}</h3>
+              <div className="text-sm">{advocate.city}</div>
+              <div className="text-sm">{advocate.phoneNumber}</div>
+              <ul className="m-4 text-sm">
+                {advocate.specialties.map((s) => (
+                  <li className="list-disc" key={s}>{s}</li>
+                ))}
+              </ul>
+              {/* <td>{advocate.yearsOfExperience}</td> */}
+              {/* <td></td> */}
+            </div>
+          );
+        })}
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
This PR adds initial styles, converting the table to a list of cards.

<img width="1302" alt="Screenshot 2025-06-09 at 4 12 55 PM" src="https://github.com/user-attachments/assets/5365fdb7-2e25-4cff-af7f-7604e4253abb" />
<br>
<br>
Cards are responsive, going from 1 column on mobile up to 3 on larger screens.
<br>
<br>
<img width="766" alt="Screenshot 2025-06-09 at 4 14 33 PM" src="https://github.com/user-attachments/assets/7ad5b8d5-d42e-4d1e-856b-d90f182d93d2" />

<img width="775" alt="Screenshot 2025-06-09 at 4 14 42 PM" src="https://github.com/user-attachments/assets/22b7f711-6652-4565-b2e5-3e65d2a3d5e3" />

## To Dos:
- Search section is unformatted and...ugly
- Phone numbers are unformatted.
- Specialties take up a lot of room visually. Perhaps collapse or .join() into a paragraph instead of a list.
- Cards are missing some personality